### PR TITLE
fix(release): remove .rc from the version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "git-commitizen"
-version = "0.1.0-rc.3"
+version = "0.1.0"
 edition = "2021"
 authors = ["Jain Ramchurn"]
 description = "A simple commitizen CLI tool in rust"


### PR DESCRIPTION
remove .rc from the version to attempt building the brew package. With the rc name it considers that this is a pre-release and skips it.