### PR TITLE
feat: make adding footer optional and remove the final confirm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is `git-cz`, a Rust-based commitizen CLI tool that helps create conventional commits. The tool provides an interactive interface for selecting commit types, scopes, and descriptions, then formats them according to the conventional commits specification.
+
+## Common Commands
+
+### Build and Development
+- `cargo build` - Build the project
+- `cargo run` - Run the CLI tool locally
+- `cargo test` - Run all tests
+- `cargo install --path .` - Install the binary locally
+
+### Release and Publishing
+- `cargo dist build` - Build distribution packages
+- `release-plz release` - Automated release process using release-plz
+
+### Changelog Generation
+- `git-cliff` - Generate changelog using the cliff.toml configuration
+
+## Code Architecture
+
+### Core Components
+
+**main.rs** - Entry point with interactive prompts using promkit:
+- Displays commit type selection menu
+- Prompts for scope, description, body, and optional footer
+- Supports editor integration for longer commit bodies
+- Handles confirmation before committing
+
+**lib.rs** - Core library functions:
+- `build_commit_types()` - Defines conventional commit types (feat, fix, docs, etc.)
+- `format_commit_types()` - Formats commit types for display with proper alignment
+- `build_commit_message()` - Constructs the final commit message from components
+- `perform_commit()` - Executes the git commit using git2 library
+
+### Key Dependencies
+- `git2` - Git repository operations and committing
+- `promkit` - Interactive CLI prompts and menus
+- `tempfile` - Temporary file handling for editor integration
+
+### Conventional Commit Types
+The tool supports standard conventional commit types: feat, fix, docs, style, refactor, perf, test, chore, ci, build, revert.
+
+### Testing
+Comprehensive test suite in `tests/main_test.rs` covers:
+- Commit type building and formatting
+- Commit message construction with various scenarios
+- Git operations with temporary repositories
+- Edge cases and error conditions
+
+## Configuration Files
+
+- `cliff.toml` - git-cliff configuration for changelog generation
+- `release-plz.toml` - Automated release configuration
+- `Cargo.toml` - Standard Rust project configuration with cargo-dist setup
+
+## Development Notes
+
+The binary is named `git-cz` and integrates with git as a subcommand (allowing `git cz` usage). The tool validates staged changes exist before committing and uses git2 for all repository operations.

--- a/tests/main_test.rs
+++ b/tests/main_test.rs
@@ -75,26 +75,26 @@ fn test_build_commit_message() {
     let description = "Add new button";
     let body = "This button allows users to submit the form.";
 
-    let commit_message = build_commit_message(commit_type, scope, description, body);
+    let commit_message = build_commit_message(commit_type, scope, description, body, "");
     assert_eq!(
         commit_message,
         "feat(ui): Add new button\n\nThis button allows users to submit the form."
     );
 
-    let commit_message_no_scope = build_commit_message(commit_type, "", description, body);
+    let commit_message_no_scope = build_commit_message(commit_type, "", description, body, "");
     assert_eq!(
         commit_message_no_scope,
         "feat: Add new button\n\nThis button allows users to submit the form."
     );
 
-    let commit_message_no_body = build_commit_message(commit_type, scope, description, "");
+    let commit_message_no_body = build_commit_message(commit_type, scope, description, "", "");
     assert_eq!(commit_message_no_body, "feat(ui): Add new button");
 }
 
 #[test]
 fn test_build_commit_message_edge_cases() {
     // All empty strings
-    let empty_message = build_commit_message("", "", "", "");
+    let empty_message = build_commit_message("", "", "", "", "");
     assert_eq!(empty_message, ": ", "Empty inputs should result in ': '");
 
     // Very long strings
@@ -103,13 +103,13 @@ fn test_build_commit_message_edge_cases() {
     let long_description = "c".repeat(100);
     let long_body = "d".repeat(1000);
 
-    let long_message = build_commit_message(&long_type, &long_scope, &long_description, &long_body);
+    let long_message = build_commit_message(&long_type, &long_scope, &long_description, &long_body, "");
     assert!(long_message.starts_with(&format!("{}({}):", long_type, long_scope)));
     assert!(long_message.contains(&long_description));
     assert!(long_message.contains(&long_body));
 
     // Special characters
-    let special_message = build_commit_message("type!", "scope@", "description#", "body$");
+    let special_message = build_commit_message("type!", "scope@", "description#", "body$", "");
     assert_eq!(special_message, "type!(scope@): description#\n\nbody$");
 }
 
@@ -249,7 +249,7 @@ fn test_full_workflow() {
     let description = "Add new feature";
     let body = "This commit adds a new feature to improve user experience.";
 
-    let commit_message = build_commit_message(commit_type, scope, description, body);
+    let commit_message = build_commit_message(commit_type, scope, description, body, "");
 
     // Perform the commit
     perform_commit(temp_dir.path(), &commit_message).unwrap();


### PR DESCRIPTION
I ran calude /init,
Then gave the same prompt as I did to openai's codex:

```
Make adding a footer default to N instead of forcing a response and remove the last question about proceeding with the commit - it's superfluous
```

Then I helped it a bit because it hallucinated some answers:

```
The issue here is that Confirm from promkit hard codes y/n and expects one to be given. Can you copy the implementation and make it optional/default like you did before?
```